### PR TITLE
Parse JoinAccept (Partial)

### DIFF
--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -27,8 +27,6 @@
 #define BCN_INTV_osticks       sec2osticks(BCN_INTV_sec)
 #define TXRX_GUARD_osticks     ms2osticks(TXRX_GUARD_ms)
 #define JOIN_GUARD_osticks     ms2osticks(JOIN_GUARD_ms)
-#define DELAY_DNW1_osticks     sec2osticks(DELAY_DNW1)
-#define DELAY_DNW2_osticks     sec2osticks(DELAY_DNW2)
 #define DELAY_JACC1_osticks    sec2osticks(DELAY_JACC1)
 #define DELAY_JACC2_osticks    sec2osticks(DELAY_JACC2)
 #define DELAY_EXTDNW2_osticks  sec2osticks(DELAY_EXTDNW2)
@@ -1514,7 +1512,7 @@ static void setupRx2DnData (xref2osjob_t osjob) {
 
 static void processRx1DnData (xref2osjob_t osjob) {
     if( LMIC.dataLen == 0 || !processDnData() )
-        schedRx2(DELAY_DNW2_osticks, FUNC_ADDR(setupRx2DnData));
+        schedRx2(sec2osticks(LMIC.rxDelay +(int)DELAY_EXTDNW2), FUNC_ADDR(setupRx2DnData));
 }
 
 
@@ -1524,7 +1522,7 @@ static void setupRx1DnData (xref2osjob_t osjob) {
 
 
 static void updataDone (xref2osjob_t osjob) {
-    txDone(DELAY_DNW1_osticks, FUNC_ADDR(setupRx1DnData));
+    txDone(sec2osticks(LMIC.rxDelay), FUNC_ADDR(setupRx1DnData));
 }
 
 // ========================================
@@ -2144,6 +2142,7 @@ void LMIC_reset (void) {
     LMIC.ping.freq    =  FREQ_PING; // defaults for ping
     LMIC.ping.dr      =  DR_PING;   // ditto
     LMIC.ping.intvExp =  0xFF;
+    LMIC.rxDelay      =  DELAY_DNW1;
 #endif // !DISABLE_PING
 #if defined(CFG_us915)
     initDefaultChannels();

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -1446,6 +1446,8 @@ static bit_t processJoinAccept (void) {
     }
     LMIC.opmode &= ~(OP_JOINING|OP_TRACK|OP_REJOIN|OP_TXRXPEND|OP_PINGINI) | OP_NEXTCHNL;
     stateJustJoined();
+    LMIC.rxDelay = LMIC.frame[OFF_JA_RXDLY];
+    if (LMIC.rxDelay == 0) LMIC.rxDelay = 1;
     reportEvent(EV_JOINED);
     return 1;
 }

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -1446,6 +1446,7 @@ static bit_t processJoinAccept (void) {
     }
     LMIC.opmode &= ~(OP_JOINING|OP_TRACK|OP_REJOIN|OP_TXRXPEND|OP_PINGINI) | OP_NEXTCHNL;
     stateJustJoined();
+    LMIC.dn2Dr = LMIC.frame[OFF_JA_DLSET] & 0x0F;
     LMIC.rxDelay = LMIC.frame[OFF_JA_RXDLY];
     if (LMIC.rxDelay == 0) LMIC.rxDelay = 1;
     reportEvent(EV_JOINED);

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -2141,11 +2141,11 @@ void LMIC_reset (void) {
     LMIC.adrEnabled   =  FCT_ADREN;
     LMIC.dn2Dr        =  DR_DNW2;   // we need this for 2nd DN window of join accept
     LMIC.dn2Freq      =  FREQ_DNW2; // ditto
+    LMIC.rxDelay      =  DELAY_DNW1;
 #if !defined(DISABLE_PING)
     LMIC.ping.freq    =  FREQ_PING; // defaults for ping
     LMIC.ping.dr      =  DR_PING;   // ditto
     LMIC.ping.intvExp =  0xFF;
-    LMIC.rxDelay      =  DELAY_DNW1;
 #endif // !DISABLE_PING
 #if defined(CFG_us915)
     initDefaultChannels();

--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -201,6 +201,8 @@ struct lmic_t {
     s1_t        adrAckReq;    // counter until we reset data rate (0=off)
     u1_t        adrChanged;
 
+    u1_t        rxDelay;      // Rx delay after TX
+    
     u1_t        margin;
     bit_t       ladrAns;      // link adr adapt answer pending
     bit_t       devsAns;      // device status answer pending


### PR DESCRIPTION
Parse `Delay` and `DLsettings`->`RX2 Data rate`, tested thanks to TTN

Does not parse `DLsettings`->`RX1DRoffset` as it seems that no mechanism for that is implemented yet.
I think that adding a new field to `lmic_t` is the better way but maybe you have another idea less RAM consumming ?
Neverheless we should implement it for full LoraWAN compliance.