### PR TITLE
Move SPI freq to config.h

### DIFF
--- a/src/hal/hal.cpp
+++ b/src/hal/hal.cpp
@@ -74,7 +74,7 @@ static void hal_io_check() {
 // -----------------------------------------------------------------------------
 // SPI
 
-static const SPISettings settings(10E6, MSBFIRST, SPI_MODE0);
+static const SPISettings settings(1E6, MSBFIRST, SPI_MODE0);
 
 static void hal_spi_init () {
     SPI.begin();

--- a/src/hal/hal.cpp
+++ b/src/hal/hal.cpp
@@ -74,7 +74,7 @@ static void hal_io_check() {
 // -----------------------------------------------------------------------------
 // SPI
 
-static const SPISettings settings(1E6, MSBFIRST, SPI_MODE0);
+static const SPISettings settings(LMIC_SPI_FREQ, MSBFIRST, SPI_MODE0);
 
 static void hal_spi_init () {
     SPI.begin();

--- a/src/lmic/config.h
+++ b/src/lmic/config.h
@@ -20,6 +20,11 @@
 #define US_PER_OSTICK (1 << US_PER_OSTICK_EXPONENT)
 #define OSTICKS_PER_SEC (1000000 / US_PER_OSTICK)
 
+// Change the SPI clock speed if you encounter errors
+// communicating with the radio.
+// The standard range is 125kHz-8MHz, but some boards can go faster.
+#define LMIC_SPI_FREQ 1E6
+
 // Enable this to allow using printf() to print to the given serial port
 // (or any other Print object). This can be easy for debugging. The
 // current implementation only works on AVR, though.


### PR DESCRIPTION
10MHz as a default is too high, IMO. Better to start with a lower frequency that will work with more Arduino boards and SPI peripherals that might be on same SPI circuit.
