### PR TITLE
Avoid unwanted ack

### DIFF
--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -1107,9 +1107,6 @@ static bit_t decodeFrame (void) {
         LMIC.dnConf = (ftype == HDR_FTYPE_DCDN ? FCT_ACK : 0);
     }
 
-    if( LMIC.dnConf || (fct & FCT_MORE) )
-        LMIC.opmode |= OP_POLL;
-
     // We heard from network
     LMIC.adrChanged = LMIC.rejoinCnt = 0;
     if( LMIC.adrAckReq != LINK_CHECK_OFF )


### PR DESCRIPTION
The LMIC library is answering automatically to ACK DOWN request, with a dedicated message.
It is no wanted to increase battery life, and the LoraWAN specification states that the ACK can wait next frame up.

Furthermore, fCnt_up was not incremented despite a send message.