### PR TITLE
Remove obsolete disabling of link check

### DIFF
--- a/examples/ttn-otaa/ttn-otaa.ino
+++ b/examples/ttn-otaa/ttn-otaa.ino
@@ -51,6 +51,7 @@ void os_getDevEui (u1_t* buf) { memcpy_P(buf, DEVEUI, 8);}
 static const u1_t PROGMEM APPKEY[16] = { 0x2B, 0x7E, 0x15, 0x16, 0x28, 0xAE, 0xD2, 0xA6, 0xAB, 0xF7, 0x15, 0x88, 0x09, 0xCF, 0x4F, 0x3C };
 void os_getDevKey (u1_t* buf) {  memcpy_P(buf, APPKEY, 16);}
 
+// This is just an example; sending plain text should be avoided.
 static uint8_t mydata[] = "Hello, world!";
 static osjob_t sendjob;
 
@@ -87,10 +88,11 @@ void onEvent (ev_t ev) {
             break;
         case EV_JOINED:
             Serial.println(F("EV_JOINED"));
-
-            // Disable link check validation (automatically enabled
-            // during join, but not supported by TTN at this time).
-            LMIC_setLinkCheckMode(0);
+            // At this point, OTAA join will have enabled link check validation,
+            // and will have (re-)configured the uplink and downlink channels
+            // and data rates, as defined in the response. If your network does
+            // not support link check, then uncomment the next line:
+            // LMIC_setLinkCheckMode(0);
             break;
         case EV_RFU1:
             Serial.println(F("EV_RFU1"));
@@ -100,7 +102,6 @@ void onEvent (ev_t ev) {
             break;
         case EV_REJOIN_FAILED:
             Serial.println(F("EV_REJOIN_FAILED"));
-            break;
             break;
         case EV_TXCOMPLETE:
             Serial.println(F("EV_TXCOMPLETE (includes waiting for RX windows)"));


### PR DESCRIPTION
Disabled “LMIC_setLinkCheckMode(0)” as meanwhile TTN supports that; see https://github.com/TheThingsNetwork/ttn/commit/13e3c6d