### PR TITLE
NiceRF v1.0 module support (separate TX_en / RX_en pins )

### DIFF
--- a/src/hal/hal.cpp
+++ b/src/hal/hal.cpp
@@ -24,8 +24,10 @@ static void hal_io_init () {
     ASSERT(lmic_pins.dio[1] != LMIC_UNUSED_PIN || lmic_pins.dio[2] != LMIC_UNUSED_PIN);
 
     pinMode(lmic_pins.nss, OUTPUT);
-    if (lmic_pins.rxtx != LMIC_UNUSED_PIN)
-        pinMode(lmic_pins.rxtx, OUTPUT);
+    if (lmic_pins.rxtx[0] != LMIC_UNUSED_PIN)
+        pinMode(lmic_pins.rxtx[0], OUTPUT);
+    if (lmic_pins.rxtx[1] != LMIC_UNUSED_PIN)
+        pinMode(lmic_pins.rxtx[1], OUTPUT);
     if (lmic_pins.rst != LMIC_UNUSED_PIN)
         pinMode(lmic_pins.rst, OUTPUT);
 
@@ -38,8 +40,10 @@ static void hal_io_init () {
 
 // val == 1  => tx 1
 void hal_pin_rxtx (u1_t val) {
-    if (lmic_pins.rxtx != LMIC_UNUSED_PIN)
-        digitalWrite(lmic_pins.rxtx, val);
+    if (lmic_pins.rxtx[0] != LMIC_UNUSED_PIN)
+        digitalWrite(lmic_pins.rxtx[0], val);
+    if (lmic_pins.rxtx[1] != LMIC_UNUSED_PIN)
+        digitalWrite(lmic_pins.rxtx[1], !val);
 }
 
 // set radio RST pin to given value (or keep floating!)

--- a/src/hal/hal.h
+++ b/src/hal/hal.h
@@ -11,10 +11,11 @@
 #define _hal_hal_h_
 
 static const int NUM_DIO = 3;
+static const int NUM_RXTX = 2;
 
 struct lmic_pinmap {
     u1_t nss;
-    u1_t rxtx;
+    u1_t rxtx[NUM_RXTX];
     u1_t rst;
     u1_t dio[NUM_DIO];
 };


### PR DESCRIPTION
Added RX_en and TX_en pin definitions for a NiceRF v1 module without antenna switch.

Add RX_en and TX_en pin function NiceRF v1.0
Set/Unset RX_en and TX_en outputs for the use of NiceRF v1.0 module with manual antenna switch.