### PR TITLE
Minor cosmetic change to the serial output of the example sketches

### DIFF
--- a/examples/ttn-abp/ttn-abp.ino
+++ b/examples/ttn-abp/ttn-abp.ino
@@ -104,8 +104,8 @@ void onEvent (ev_t ev) {
             if (LMIC.txrxFlags & TXRX_ACK)
               Serial.println(F("Received ack"));
             if (LMIC.dataLen) {
-              Serial.println(F("Received "));
-              Serial.println(LMIC.dataLen);
+              Serial.print(F("Received "));
+              Serial.print(LMIC.dataLen);
               Serial.println(F(" bytes of payload"));
             }
             // Schedule next transmission

--- a/examples/ttn-otaa/ttn-otaa.ino
+++ b/examples/ttn-otaa/ttn-otaa.ino
@@ -107,8 +107,8 @@ void onEvent (ev_t ev) {
             if (LMIC.txrxFlags & TXRX_ACK)
               Serial.println(F("Received ack"));
             if (LMIC.dataLen) {
-              Serial.println(F("Received "));
-              Serial.println(LMIC.dataLen);
+              Serial.print(F("Received "));
+              Serial.print(LMIC.dataLen);
               Serial.println(F(" bytes of payload"));
             }
             // Schedule next transmission


### PR DESCRIPTION
The message "Received X bytes of payload" upon receiving a downlink packet after transmit is now on one line instead of three.