### PR TITLE
Avoiding failure after many failed requests for US915 join

### DIFF
--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -907,7 +907,7 @@ static ostime_t nextJoinState (void) {
     } else {
         LMIC.txChnl = os_getRndU1() & 0x3F;
         s1_t dr = DR_SF7 - ++LMIC.txCnt;
-        if( dr < DR_SF10 ) {
+        if( LMIC.txCnt > DR_SF7 ) {
             dr = DR_SF10;
             failed = 1; // All DR exhausted - signal failed
         }


### PR DESCRIPTION
This PR provides a solution for #193

Currently, if there are more than 132 failed Join requests, the datarate (an 8-bit signed int) will overflow, and the "override to SF10" behavior will fail. This eventually leads to a execution failure and cpu halt. 

This change allows everything to function as intended, until the txCnt increases past 255, at which point it will simply start again from 0 without a failure.