### PR TITLE
Fix RSSI and SNR calculation

### DIFF
--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -1134,7 +1134,7 @@ static bit_t decodeFrame (void) {
         LMIC.adrAckReq = LINK_CHECK_INIT;
 
     // Process OPTS
-    int m = LMIC.rssi - RSSI_OFF - getSensitivity(LMIC.rps);
+    int m = (int)LMIC.rssi - getSensitivity(LMIC.rps);
     LMIC.margin = m < 0 ? 0 : m > 254 ? 254 : m;
 
     xref2u1_t opts = &d[OFF_DAT_OPTS];

--- a/src/lmic/lmic.h
+++ b/src/lmic/lmic.h
@@ -95,7 +95,7 @@ enum { BCN_NONE    = 0x00,   //!< No beacon received
 //! Information about the last and previous beacons.
 struct bcninfo_t {
     ostime_t txtime;  //!< Time when the beacon was sent
-    s1_t     rssi;    //!< Adjusted RSSI value of last received beacon
+    s2_t     rssi;    //!< Adjusted RSSI value of last received beacon
     s1_t     snr;     //!< Scaled SNR value of last received beacon
     u1_t     flags;   //!< Last beacon reception and tracking states. See BCN_* values.
     u4_t     time;    //!< GPS time in seconds of last beacon (received or surrogate)
@@ -153,7 +153,7 @@ struct lmic_t {
     ostime_t    txend;
     ostime_t    rxtime;
     u4_t        freq;
-    s1_t        rssi;
+    s2_t        rssi;
     s1_t        snr;
     rps_t       rps;
     u1_t        rxsyms;

--- a/src/lmic/lorabase.h
+++ b/src/lmic/lorabase.h
@@ -342,7 +342,9 @@ enum {
 typedef u4_t devaddr_t;
 
 // RX quality (device)
-enum { RSSI_OFF=64, SNR_SCALEUP=4 };
+enum { RSSI_OFF=0, SNR_SCALEUP=4 }; // use RSSI_OFF to compensate any loss
+                                    // in the matching network or even the gain of an
+                                    // additional LNA
 
 inline sf_t  getSf   (rps_t params)            { return   (sf_t)(params &  0x7); }
 inline rps_t setSf   (rps_t params, sf_t sf)   { return (rps_t)((params & ~0x7) | sf); }

--- a/src/lmic/radio.c
+++ b/src/lmic/radio.c
@@ -785,7 +785,7 @@ void radio_irq_handler (u1_t dio) {
             // now read the FIFO
             readBuf(RegFifo, LMIC.frame, LMIC.dataLen);
             // read rx quality parameters
-            LMIC.snr  = readReg(LORARegPktSnrValue) / 4;
+            LMIC.snr  = ((s1_t)readReg(LORARegPktSnrValue)) / 4;
             LMIC.rssi = readReg(LORARegPktRssiValue) - 157; // RFI_HF for 868 and 915MHZ band
             if (LMIC.snr < 0)
                 LMIC.rssi += LMIC.snr;

--- a/src/lmic/radio.c
+++ b/src/lmic/radio.c
@@ -785,8 +785,10 @@ void radio_irq_handler (u1_t dio) {
             // now read the FIFO
             readBuf(RegFifo, LMIC.frame, LMIC.dataLen);
             // read rx quality parameters
-            LMIC.snr  = readReg(LORARegPktSnrValue); // SNR [dB] * 4
-            LMIC.rssi = readReg(LORARegPktRssiValue) - 125 + 64; // RSSI [dBm] (-196...+63)
+            LMIC.snr  = readReg(LORARegPktSnrValue) / 4;
+            LMIC.rssi = readReg(LORARegPktRssiValue) - 157; // RFI_HF for 868 and 915MHZ band
+            if (LMIC.snr < 0)
+                LMIC.rssi += LMIC.snr;
         } else if( flags & IRQ_LORA_RXTOUT_MASK ) {
             // indicate timeout
             LMIC.dataLen = 0;

--- a/src/lmic/radio.c
+++ b/src/lmic/radio.c
@@ -742,9 +742,9 @@ u1_t radio_rand1 () {
     return v;
 }
 
-u1_t radio_rssi () {
+s2_t radio_rssi () {
     hal_disableIRQs();
-    u1_t r = readReg(LORARegRssiValue);
+    s2_t r = (s2_t) (0x00FF & (u2_t)readReg(LORARegRssiValue));
     hal_enableIRQs();
     return r;
 }
@@ -785,10 +785,12 @@ void radio_irq_handler (u1_t dio) {
             // now read the FIFO
             readBuf(RegFifo, LMIC.frame, LMIC.dataLen);
             // read rx quality parameters
-            LMIC.snr  = ((s1_t)readReg(LORARegPktSnrValue)) / 4;
-            LMIC.rssi = readReg(LORARegPktRssiValue) - 157; // RFI_HF for 868 and 915MHZ band
+            LMIC.snr  = ((s1_t)readReg(LORARegPktSnrValue)) / SNR_SCALEUP;
+            LMIC.rssi = radio_rssi() - 157 + RSSI_OFF; // use RSSI_OFF to compensate any loss
+                                                                                              // in the matching network or even the gain of an
+                                                                                              // additional LNA
             if (LMIC.snr < 0)
-                LMIC.rssi += LMIC.snr;
+                LMIC.rssi += (s2_t)LMIC.snr;
         } else if( flags & IRQ_LORA_RXTOUT_MASK ) {
             // indicate timeout
             LMIC.dataLen = 0;
@@ -811,8 +813,8 @@ void radio_irq_handler (u1_t dio) {
             // now read the FIFO
             readBuf(RegFifo, LMIC.frame, LMIC.dataLen);
             // read rx quality parameters
-            LMIC.snr  = 0; // determine snr
-            LMIC.rssi = 0; // determine rssi
+            LMIC.snr  = 0; // determine snr  - TO DO
+            LMIC.rssi = 0; // determine rssi - TO DO
         } else if( flags1 & IRQ_FSK1_TIMEOUT_MASK ) {
             // indicate timeout
             LMIC.dataLen = 0;


### PR DESCRIPTION
Fix method to calculate RSSI and SNR as specified in SX1276/77/78/79 semtech datasheet chapter "**_5.5.5. RSSI and SNR in LoRa TM Mode_**" in src/lmic/radio.c file