### PR TITLE
Power fix SX1276 (txpow now works)

### DIFF
--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -500,6 +500,11 @@ static void setDrTxpow (u1_t reason, u1_t dr, s1_t pow) {
                         e_.txpow     = pow,
                         e_.prevdr    = LMIC.datarate|DR_PAGE,
                         e_.prevtxpow = LMIC.adrTxPow));
+						
+	// Setting the power in the band makes it effective					
+	LMIC.bands[BAND_CENTI].txpow = pow; 
+	LMIC.bands[BAND_MILLI].txpow = pow; 
+	LMIC.bands[BAND_DECI].txpow = pow; 						
 
     if( pow != KEEP_TXPOW )
         LMIC.adrTxPow = pow;

--- a/src/lmic/radio.c
+++ b/src/lmic/radio.c
@@ -261,6 +261,20 @@ static u1_t randbuf[16];
 #endif
 
 
+// defines from LoraNode SX1276 https://github.com/Lora-net/LoRaMac-node
+#define REG_PACONFIG                                0x09
+#define REG_PADAC                                   0x4D
+#define RF_PACONFIG_PASELECT_MASK                   0x7F
+#define RF_PACONFIG_MAX_POWER_MASK                  0x8F
+#define RFLR_PACONFIG_PASELECT_PABOOST              0x80
+#define RF_PADAC_20DBM_MASK                         0xF8
+#define RF_PADAC_20DBM_ON                           0x07
+#define RF_PADAC_20DBM_OFF                          0x04  // Default
+#define RF_PACONFIG_OUTPUTPOWER_MASK                0xF0
+#define RF_PACONFIG_PASELECT_PABOOST                0x80
+
+
+
 static void writeReg (u1_t addr, u1_t data ) {
     hal_pin_nss(0);
     hal_spi(addr | 0x80);
@@ -396,19 +410,76 @@ static void configChannel () {
 }
 
 
+static void SX1276SetRfTxPower( s1_t power)
+{
+    uint8_t paConfig = 0;
+    uint8_t paDac = 0;
+
+    paConfig = readReg( REG_PACONFIG );
+    paDac = readReg( REG_PADAC );
+
+    paConfig = ( paConfig & RF_PACONFIG_PASELECT_MASK ) | RF_PACONFIG_PASELECT_PABOOST;
+    paConfig = ( paConfig & RF_PACONFIG_MAX_POWER_MASK ) | 0x70;
+
+    if( ( paConfig & RF_PACONFIG_PASELECT_PABOOST ) == RF_PACONFIG_PASELECT_PABOOST )
+    {
+        if( power > 17 )
+        {
+            paDac = ( paDac & RF_PADAC_20DBM_MASK ) | RF_PADAC_20DBM_ON;
+        }
+        else
+        {
+            paDac = ( paDac & RF_PADAC_20DBM_MASK ) | RF_PADAC_20DBM_OFF;
+        }
+        if( ( paDac & RF_PADAC_20DBM_ON ) == RF_PADAC_20DBM_ON )
+        {
+            if( power < 5 )
+            {
+                power = 5;
+            }
+            if( power > 20 )
+            {
+                power = 20;
+            }
+            paConfig = ( paConfig & RF_PACONFIG_OUTPUTPOWER_MASK ) | ( uint8_t )( ( uint16_t )( power - 5 ) & 0x0F );
+        }
+        else
+        {
+            if( power < 2 )
+            {
+                power = 2;
+            }
+            if( power > 17 )
+            {
+                power = 17;
+            }
+            paConfig = ( paConfig & RF_PACONFIG_OUTPUTPOWER_MASK ) | ( uint8_t )( ( uint16_t )( power - 2 ) & 0x0F );
+        }
+    }
+    else
+    {
+        if( power < -1 )
+        {
+            power = -1;
+        }
+        if( power > 14 )
+        {
+            power = 14;
+        }
+        paConfig = ( paConfig & RF_PACONFIG_OUTPUTPOWER_MASK ) | ( uint8_t )( ( uint16_t )( power + 1 ) & 0x0F );
+    }
+    writeReg( REG_PACONFIG, paConfig );
+    writeReg( REG_PADAC, paDac );
+}
+
+
 
 static void configPower () {
 #ifdef CFG_sx1276_radio
     // no boost used for now
     s1_t pw = (s1_t)LMIC.txpow;
-    if(pw >= 17) {
-        pw = 15;
-    } else if(pw < 2) {
-        pw = 2;
-    }
-    // check board type for BOOST pin
-    writeReg(RegPaConfig, (u1_t)(0x80|(pw&0xf)));
-    writeReg(SX1276_RegPaDac, readReg(SX1276_RegPaDac)|0x4);
+    SX1276SetRfTxPower( pw);
+	
 
 #elif CFG_sx1272_radio
     // set PA config (2-17 dBm using PA_BOOST)

--- a/src/lmic/radio.c
+++ b/src/lmic/radio.c
@@ -118,6 +118,7 @@
 // #define RegPllHop                                  0x4B // common
 // #define RegTcxo                                    0x58 // common
 #define RegPaDac                                   0x5A // common
+#define SX1276_RegPaDac                            0x4D // not common
 // #define RegPll                                     0x5C // common
 // #define RegPllLowPn                                0x5E // common
 // #define RegFormerTemp                              0x6C // common
@@ -407,7 +408,7 @@ static void configPower () {
     }
     // check board type for BOOST pin
     writeReg(RegPaConfig, (u1_t)(0x80|(pw&0xf)));
-    writeReg(RegPaDac, readReg(RegPaDac)|0x4);
+    writeReg(SX1276_RegPaDac, readReg(SX1276_RegPaDac)|0x4);
 
 #elif CFG_sx1272_radio
     // set PA config (2-17 dBm using PA_BOOST)


### PR DESCRIPTION
 This pull request aims to fix the issue of txpow not working

in the example I see:
// Set data rate and transmit power for uplink (note: txpow seems to be ignored by the library)

the 3 changes are
1) I found that there was an error in the RegPaDac address for SX1276 (that is different from SX1272 as believed before)
2) I borrowed the code for setting the power from https://github.com/Lora-net/LoRaMac-node since the previous one was not working.
3) I had to set the power in a specific way to make it really working. See line  504 of lmic.c (I'm not sue if this brakes something related to ADR but at least It makes setting the power manually working.)

Ciao
Marco

