### PR TITLE
docs: fix simple typo, onging -> ongoing

### DIFF
--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -1779,7 +1779,7 @@ static void startScan (void) {
     ASSERT(LMIC.devaddr!=0 && (LMIC.opmode & OP_JOINING)==0);
     if( (LMIC.opmode & OP_SHUTDOWN) != 0 )
         return;
-    // Cancel onging TX/RX transaction
+    // Cancel ongoing TX/RX transaction
     LMIC.txCnt = LMIC.dnConf = LMIC.bcninfo.flags = 0;
     LMIC.opmode = (LMIC.opmode | OP_SCAN) & ~(OP_TXRXPEND);
     setBcnRxParams();


### PR DESCRIPTION
There is a small typo in src/lmic/lmic.c.

Should read `ongoing` rather than `onging`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md